### PR TITLE
Allow report generators to skip output for pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ the `BaseReportGenerator`. You will then have to implement three methods:
 - `headers()`: an array of the names of the headers that your report should contain
 - `preprocess_page(content_item, html)`: the main component of your report generator, which takes a content item from
 the preprocessed content store and the HTML content of that page, runs some computation and returns an array which
-corresponds to the output for that page to be included in the report CSV
+corresponds to the output for that page to be included in the report CSV.
+    - You can return an empty array (`[]`) if the page you're processing should not be recorded in the CSV for whatever
+    reason / if you want to skip particular pages etc.
 
 Once you have created the report generator, you should add a new entry to the `reports` property in the
 `report-config.yaml` config file representing this report. The entry should contain:

--- a/src/pipeline/report_runner.py
+++ b/src/pipeline/report_runner.py
@@ -158,7 +158,10 @@ class ReportRunner:
                     # This is because a generator might wish to skip certain pages, so we shouldn't mandate an output
                     # for every page, and we don't want to introduce unnecessary logic here to second-guess what the
                     # generator may or may not return
-                    queue.put(report_generator.process_page(content_item, html))
+                    result = report_generator.process_page(content_item, html)
+
+                    if any(result):
+                        queue.put(result)
 
             return
 


### PR DESCRIPTION
This PR allows the report generators to skip sending output for certain pages, if there isn't any relevant output to record in the CSV for a particular report. This saves us from generating reports that might contain many empty rows, which isn't useful for anyone.

Report generators can take advantage of this by returning an empty array as the processing result for a particular GOV.UK page, which is then checked by the `ReportRunner` before being pushed on to the CSV write queue (this is more efficient than having the CSV writer check, as the CSV writer will already be busy and any more processing we push to it will only slow things down).