### PR TITLE
Add link text report

### DIFF
--- a/report-config.yaml
+++ b/report-config.yaml
@@ -7,6 +7,10 @@ reports:
     filename: non_english_docs_report_generator.py
     class: NonEnglishDocsReportGenerator
     skip: true
+  - name: Links that have same text but different URLs
+    filename: link_text_report_generator.py
+    class: LinkTextReportGenerator
+    skip: true
 
 settings:
   turbo_mode: false

--- a/src/report_generators/link_text_report_generator.py
+++ b/src/report_generators/link_text_report_generator.py
@@ -1,0 +1,129 @@
+import ast
+import json
+
+from bs4 import BeautifulSoup
+from src.report_generators.base_report_generator import BaseReportGenerator
+
+
+class LinkTextReportGenerator(BaseReportGenerator):
+
+    @property
+    def filename(self):
+        return "link_text_report.csv"
+
+    @property
+    def headers(self):
+        return ["base_path", "title", "document_type", "publishing_app", "publishing_org", "links_compliant",
+                "non_compliant_links"]
+
+    def process_page(self, content_item, html):
+        non_compliant_links = self.non_compliant_links(html)
+        links_are_compliant = not any(non_compliant_links)
+
+        if links_are_compliant:
+            return []
+
+        row = [f"https://www.gov.uk{content_item['base_path']}", content_item.get('title', ''),
+               content_item.get('document_type', ''), content_item.get('publishing_app', ''),
+               ";".join(self._primary_publishing_organisation(content_item)),
+               str(links_are_compliant), "\n".join(non_compliant_links)]
+
+        return row
+
+    def links_are_compliant(self, html):
+        return not any(self.non_compliant_links(html))
+
+    def non_compliant_links(self, html):
+        """
+        Returns non compliant links
+        Will return links that have the same link text but different urls
+        >>> item = ContentItem('/education')
+        >>> item.html = "<a href='https://www.gov.uk/page_one'>one</a><a href='https://www.gov.uk/page_two'>one</a>"
+        "<a href='https://www.gov.uk/page_three'>three</a>"
+        >>> item.non_compliant_links()
+        ['There are 2 links all with text `one` that point to different urls: https://www.gov.uk/page_one,
+        https://www.gov.uk/page_two']
+        """
+
+        soup = BeautifulSoup(html, features="html.parser")
+        links_by_text = {}
+
+        excluded_link_texts = [
+            'Request an accessible format.'
+        ]
+
+        excluded_link_urls = [
+            '#content',
+            'https://www.gov.uk/'
+        ]
+
+        excluded_link_url_prefixes = [
+            '#',
+            'mailto:'
+        ]
+
+        for link in soup.findAll('a'):
+            if self._is_not_feedback(link) and self._is_not_global_bar(link) and self._is_not_cookie_banner(
+                    link) and self._is_not_footer(link) and self._is_not_skip_link(link):
+                text = " ".join(list(link.stripped_strings))
+
+                if text in excluded_link_texts:
+                    continue
+
+                if len(text) > 0:
+                    href = link['href']
+
+                    # There will always be different links to the homepage on every page,
+                    # which include "GOV.UK" and "Home". Including this would make the
+                    # analysis a lot more noisy and less useful.
+                    if href in excluded_link_urls or any(href.startswith(prefix)
+                                                         for prefix in excluded_link_url_prefixes):
+                        continue
+
+                    if text not in links_by_text:
+                        links_by_text[text] = []
+
+                    # We know relative links point to GOV.UK, so specify this in the href to reduce false matches
+                    if href.startswith('/'):
+                        href = f"https://www.gov.uk{href}"
+
+                    links_by_text[text].append(href)
+
+        non_compliant_links = []
+
+        # A link points to a unique destination, but uses the same text as other links;
+        for link_text, hrefs in links_by_text.items():
+            if len(list(set(hrefs))) > 1:
+                problem_urls = '\n\t'.join(hrefs)
+                problem_statement = f"There are {len(hrefs)} links all with text `{link_text}` that point to " \
+                    f"different urls:\n\t{problem_urls}\n"
+                non_compliant_links.append(problem_statement)
+
+        return non_compliant_links
+
+    @staticmethod
+    def _is_not_feedback(link):
+        return not any(link.find_parents("div", {'class': 'gem-c-feedback'}))
+
+    @staticmethod
+    def _is_not_global_bar(link):
+        return not any(link.find_parents("div", {'id': 'global-bar'}))
+
+    @staticmethod
+    def _is_not_cookie_banner(link):
+        return not any(link.find_parents("div", {'id': 'global-cookie-message'}))
+
+    @staticmethod
+    def _is_not_footer(link):
+        return not any(link.find_parents("footer", {'id': 'footer'}))
+
+    @staticmethod
+    def _is_not_skip_link(link):
+        return not any(link.find_parents("div", {'id': 'skiplink-container'}))
+
+    @staticmethod
+    def _primary_publishing_organisation(content_item):
+        organisations_json = json.loads(json.dumps((content_item.get("organisations", ""))))
+        organisations = ast.literal_eval(organisations_json)
+
+        return list(map(lambda org: org[1], organisations.get("primary_publishing_organisation", {})))


### PR DESCRIPTION
This PR adds a link text report, which checks for GOV.UK pages containing links with the same text that point to different URLs. This report was originally written by Oscar in the Knowledge Graph repo, and this commit ports it over to be run via the `ReportRunner`, whilst refactoring to remove all logic requesting GOV.UK pages and instead using the information we have in the content item and HTML markup for any particular page. It also includes some additional filters for links that the Accessibility team don't wish to appear in the results (such as requesting accessible versions of documents etc).