### PR TITLE
Check for existence of href in <a> tags

### DIFF
--- a/src/report_generators/link_text_report_generator.py
+++ b/src/report_generators/link_text_report_generator.py
@@ -70,7 +70,7 @@ class LinkTextReportGenerator(BaseReportGenerator):
                 if text in excluded_link_texts:
                     continue
 
-                if len(text) > 0:
+                if len(text) > 0 and 'href' in link:
                     href = link['href']
 
                     # There will always be different links to the homepage on every page,


### PR DESCRIPTION
This PR checks for the existence of the `href` property of `<a>` tags before trying to get the value. From running the link text report generator this problem was noticed - we might want to call this out separately in the future. If the `href` property isn't found for a link, we set the link to `'https://www.gov.uk/'` (which we skip over by default).