### PR TITLE
Feature: Inaccessible non-html pages

### DIFF
--- a/config/report-config.yaml
+++ b/config/report-config.yaml
@@ -15,11 +15,15 @@ reports:
     filename: link_text_report_generator.py
     class: LinkTextReportGenerator
     skip: true
+  - name: Find pages with non-HTML attachments
+    filename: non_html_attachment_report_generator.py
+    class: NonHtmlAttachmentReportGenerator
+    skip: true
 
 settings:
   turbo_mode: false
   html_content_dir_path: /absolute/path/to/html/content/dir
   preprocessed_content_store_path: /absolute/path/to/preprocessed_content_store.csv.gz
-  total_content_items: 1000
+  total_content_items: 10000
   content_item_batch_size: 50000
   csv_writer_buffer_size: 500

--- a/notebooks/non_html_page_report_postprocess.py
+++ b/notebooks/non_html_page_report_postprocess.py
@@ -1,0 +1,49 @@
+from src.helpers.preprocess_text import extract_from_path
+
+import pandas as pd
+import numpy as np
+import ast
+
+# import data
+df = pd.read_csv(filepath_or_buffer='data/non_html_page_report.csv')
+
+# explode so we have one attachment for each row
+df['attachment_path'] = df['attachment_path'].apply(ast.literal_eval)
+df_long = df.explode(column='attachment_path').copy()
+
+# extract links
+df_long['attachment_ext'] = df_long['attachment_path'].apply(lambda x: extract_from_path(data=x,
+                                                                                         part='ext'))
+# un-nest so can easily replace blanks
+df_long['attachment_ext'] = df_long['attachment_ext'].apply(lambda x: ''.join(x))
+df_long['attachment_ext'] = df_long['attachment_ext'].replace(to_replace='',
+                                                              value=np.NaN)
+
+# remove non-attachment and empty rows
+df_long = df_long.dropna(subset=['attachment_path', 'attachment_ext'], how='any', axis=0)
+
+# filter for after Sep 2018 for Specialist and Travel Advice publishers
+df_long['first_published_at'] = df_long['first_published_at'].astype('datetime64[ns]')
+cond_one = (df_long['publishing_app'] == 'specialist-publisher') & (df_long['first_published_at'] > '2018-09-30')
+cond_two = (df_long['publishing_app'] == 'travel-advice-publisher') & (df_long['first_published_at'] > '2018-09-30')
+cond_three = df_long['publishing_app'].isin(['publisher', 'service-manual-publisher'])
+df_long = df_long[cond_one | cond_two | cond_three].copy()
+
+# export three sets of files
+#   i. all data in one file
+#   ii. sample data in one file (for viewing purposes)
+#   iii. all data but split by primary publishing organisation (for viewing purposes)
+
+# i.
+df_long.to_csv(path_or_buf='data/inaccessible_nonhtml_reports/full.csv', index=False)
+
+# ii.
+df_long.sample(n=10000, random_state=42).to_csv(path_or_buf='data/inaccessible_nonhtml_reports/sample.csv',
+                                                index=False)
+
+# iii.
+df_long = df_long.set_index('publishing_app')
+for key in df_long.index.unique():
+    df_long.loc[key].to_csv('data/inaccessible_nonhtml_reports/{}.csv'.format(key),
+                            index=False,
+                            header=True)

--- a/src/report_generators/non_html_attachment_report_generator.py
+++ b/src/report_generators/non_html_attachment_report_generator.py
@@ -1,0 +1,116 @@
+from src.report_generators.base_report_generator import BaseReportGenerator
+from src.helpers.preprocess_text import extract_links_from_html
+from src.helpers.preprocess_text import extract_attachment_smart
+from src.helpers.preprocess_text import extract_from_path
+
+import ast
+import re
+
+import pandas as pd
+
+
+class NonHtmlAttachmentReportGenerator(BaseReportGenerator):
+    @property
+    def headers(self):
+        return ["base_path",
+                "primary_publishing_organisation",
+                "publishing_app",
+                "document_type",
+                "first_published_at",
+                "attachment_path"]
+
+    @property
+    def filename(self):
+        return "test_non_html_page_report.csv"
+
+    def process_page(self, content_item, html):
+
+        content_item['primary_publishing_organisation'] = self.extract_subtext(text=content_item['organisations'],
+                                                                               key='primary_publishing_organisation',
+                                                                               index=1)
+
+        # ignore cases we do not want to return
+        publishers = ["publisher", "service-manual-publisher", "specialist-publisher", "travel-advice-publisher"]
+        if not content_item['publishing_app'] in publishers:
+            return []
+
+        attachments = (".chm|.csv|.diff|.doc|.docx|.dot|.dxf|.eps|"
+                       + ".gif|.gml|.ics|.jpg|.kml|.odp|.ods|.odt|.pdf|"
+                       + ".png|.ppt|.pptx|.ps|.rdf|.ris|.rtf|.sch|.txt|"
+                       + ".vcf|.wsdl|.xls|.xlsm|.xlsx|.xlt|.xml|.xsd|.xslt|"
+                       + ".zip")
+        if not any(re.findall(pattern=attachments, string=content_item['details'])):
+            return []
+
+        if pd.isna(content_item['details']):
+            return []
+
+        # extract attachment url
+        # each method gives different results
+        # need both methods to capture different ways attachments can be on webpage
+        content_item['attachment_url_one'] = extract_links_from_html(text=content_item['details'])
+        content_item['attachment_url_two'] = self.extract_attachment(text=content_item['details'],
+                                                                     element='url')
+        content_item['attachment_url_three'] = extract_attachment_smart(text=content_item['details'])
+
+        # combine two lists
+        content_item['attachment_path'] = content_item['attachment_url_one'] \
+                                          + content_item['attachment_url_two'] \
+                                          + content_item['attachment_url_three']
+        # remove duplicates
+        content_item['attachment_path'] = list(dict.fromkeys(content_item['attachment_path']))
+
+        # extract file extension from attachment url
+        content_item['attachment_ext'] = extract_from_path(data=content_item['attachment_path'],
+                                                           part='ext')
+
+        # return only pages with attachments by ignoring empty lists
+        if not content_item['attachment_ext']:
+            return []
+        else:
+            return [content_item['base_path'],
+                    content_item['primary_publishing_organisation'],
+                    content_item['publishing_app'],
+                    content_item['document_type'],
+                    content_item['first_published_at'],
+                    content_item['attachment_path']]
+
+    def extract_subtext(self, text, key, index=0):
+        """
+        Extracts the value of a key within a dictionary masquerading as a string
+
+        :param text: A string that's in the format of a dictionary
+        :param key: The name of the key you want to extract the associated value from
+        :param index: The index of specific value if you extracted more than one value from the key
+        :return: the extracted value of the key
+        """
+        try:
+
+            # convert to dictionary
+            dictionary = ast.literal_eval(text)
+
+            # extract value of key entered from dictionary
+            list_keys = list(map(lambda x: x[index], dictionary.get(key, {})))
+
+            return list_keys
+        except (ValueError, SyntaxError):
+            return []
+
+    def extract_attachment(self, text, element):
+        """
+        Extracts all the 'attachments' from a specified 'section' from GOV.UK pages
+
+        :param text: String of the HTML code for the GOV.UK page being passed in
+        :param element: The `element` within `section` part of HTML code to extract the contents of e.g. 'title', 'url'
+        :return: list of all the attachment 'element' that were extracted from GOV.UK page
+        """
+
+        try:
+            text = ast.literal_eval(text)
+            text = text.get('attachments')
+
+            text = list(map(lambda x: x[element], text))
+            return text
+
+        except (ValueError, TypeError):
+            return []


### PR DESCRIPTION
# Summary
We know there are some inaccessible (non-HTML) attachments on GOV.UK.

We want to make sure we have find and reviewed them all if they are owned by GDS to check that they are accessible and determine what needs to be done.

Whitehall reports can be gotten from Whitehall so they are exempt from this report

All documents link to the asset manager

More info:
https://trello.com/c/fYgv7Pu9

## Check
- [ ] We have a list of GDS (mainstream and service manual publisher) pages, their attachments and attachment extensions
- [ ] We have a list of pages from specialist and travel advice publisher - the department, the page, attachment and extensions
- [ ] Report should have date it was first published