### PR TITLE
Add visidata instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ tool [visidata](https://www.visidata.org/).  The following command opens the
 file without decompressing the whole thing.
 
 ```sh
-zcat preprocessed_content_store_011020.csv.gz | vd --filetype=csv --csv-delimiter=$'\t' -
+zcat < preprocessed_content_store_011020.csv.gz | vd --filetype=csv --csv-delimiter=$'\t' -
 ```
 
 You can expand the JSON columns by highlighting the column and typing


### PR DESCRIPTION
Explain in the README how to use the visidata command-line tool to explore the preprocessed_content_store.csv.gz file without decompressing the whole thing, and be able to expand the JSON columns.﻿﻿
