### PR TITLE
Update GOV.UK Cookie Banner text

### DIFF
--- a/src/utils/html_extractor.py
+++ b/src/utils/html_extractor.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 class HtmlExtractor:
     header_regex = re.compile("^h[1-6]{1}$")
     excluded_headings = [
-        "Tell us whether you accept cookies"
+        "Cookies on GOV.UK"
     ]
 
     @classmethod


### PR DESCRIPTION
The GOV.UK Cookie banner text has changed, updating this text will ensure it is excluded when generating heading order reports.