### PR TITLE
Add additional WrongStart column to Heading report to detect non-h1 starts

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+accessibility-reports

--- a/src/report_generators/heading_ordering_report_generator.py
+++ b/src/report_generators/heading_ordering_report_generator.py
@@ -6,7 +6,7 @@ from src.helpers.preprocess_text import extract_primary_org_from_organisations
 class HeadingOrderingReportGenerator(BaseReportGenerator):
     @property
     def headers(self):
-        return ["base_path", "primary_publishing_organisation", "has_valid_headings", "has_duplicate_h1s", "has_bad_ordering", "has_no_headings",
+        return ["base_path", "primary_publishing_organisation", "has_valid_headings", "has_duplicate_h1s", "has_wrong_start", "has_bad_ordering", "has_no_headings",
                 "heading_order"]
 
     @property
@@ -20,7 +20,7 @@ class HeadingOrderingReportGenerator(BaseReportGenerator):
         primary_publishing_organisation = extract_primary_org_from_organisations(content_item['organisations'])
 
         row = [content_item['base_path'], primary_publishing_organisation, heading_accessibility_info.is_valid(),
-               heading_accessibility_info.has_duplicate_h1s(), heading_accessibility_info.has_bad_ordering(),
+               heading_accessibility_info.has_duplicate_h1s(), heading_accessibility_info.has_wrong_start(), heading_accessibility_info.has_bad_ordering(),
                heading_accessibility_info.has_no_headings(), heading_accessibility_info.heading_order()]
 
         return row

--- a/src/utils/heading_accessibility_info.py
+++ b/src/utils/heading_accessibility_info.py
@@ -1,9 +1,10 @@
 class HeadingAccessibilityInfo:
-    def __init__(self, headings, duplicate_h1s=False, bad_ordering=False, no_headings=False):
+    def __init__(self, headings, duplicate_h1s=False, bad_ordering=False, no_headings=False, wrong_start=False):
         self.headings = headings
         self.duplicate_h1s = duplicate_h1s
         self.bad_ordering = bad_ordering
         self.no_headings = no_headings
+        self.wrong_start = wrong_start
 
     def heading_order(self):
         return self.headings
@@ -17,5 +18,8 @@ class HeadingAccessibilityInfo:
     def has_no_headings(self):
         return self.no_headings
 
+    def has_wrong_start(self):
+        return self.wrong_start
+
     def is_valid(self):
-        return not self.has_duplicate_h1s() and not self.has_bad_ordering() and not self.has_no_headings()
+        return not self.has_duplicate_h1s() and not self.has_bad_ordering() and not self.has_no_headings() and not self.has_wrong_start()

--- a/src/utils/html_validator.py
+++ b/src/utils/html_validator.py
@@ -10,19 +10,21 @@ class HtmlValidator:
     def validate_headings_accessibility(html):
         headings = HtmlExtractor.extract_headings(html)
         number_of_headings = len(headings)
+        wrong_start = False
 
         if number_of_headings == 0:
             return HeadingAccessibilityInfo(headings='', no_headings=True)
 
         if headings[0] != 'h1':
-            return HeadingAccessibilityInfo(headings=headings[0], bad_ordering=True)
+          wrong_start=True
 
-        if number_of_headings == 1:
+        if number_of_headings == 1 and not wrong_start:
             return HeadingAccessibilityInfo(headings='h1')
 
         heading_levels = [int(heading.replace('h', '')) for heading in headings]
         duplicate_h1s = False
         bad_ordering = False
+
 
         for i in range(1, number_of_headings):
             previous_level = heading_levels[i - 1]
@@ -35,7 +37,7 @@ class HtmlValidator:
                 bad_ordering = True
 
         return HeadingAccessibilityInfo(headings=", ".join(headings), duplicate_h1s=duplicate_h1s,
-                                        bad_ordering=bad_ordering)
+                                        bad_ordering=bad_ordering, wrong_start=wrong_start)
 
     def validate_table_accessibility(html):
         tables = HtmlTableExtractor.extract_tables(html)

--- a/tests/fixtures/html.py
+++ b/tests/fixtures/html.py
@@ -1,0 +1,33 @@
+import pytest
+
+
+@pytest.fixture
+def good_html():
+    html = f"""
+<html>
+<head>
+    <title>Good HTML</title>
+</head>
+<body>
+    <h1>Heading 1</h1>
+    <h2>heading 2</h2>
+</body>
+</html>
+"""
+
+    return html
+
+@pytest.fixture
+def wrong_start():
+    html = f"""
+<html>
+<head>
+    <title>Wrong Start</title>
+</head>
+<body>
+<h2>Bad heading 2</h2>
+</body>
+</html>
+"""
+
+    return html

--- a/tests/utils/test_html_validator.py
+++ b/tests/utils/test_html_validator.py
@@ -2,8 +2,10 @@ import pytest
 
 from src.utils.html_validator import HtmlValidator
 from src.utils.table_accessibility_info import TableAccessibilityInfo
+from src.utils.heading_accessibility_info import HeadingAccessibilityInfo
 
 from tests.fixtures.tables import two_tables
+from tests.fixtures.html import good_html, wrong_start
 
 
 def test_validate_table_accessibility(two_tables):
@@ -11,3 +13,12 @@ def test_validate_table_accessibility(two_tables):
 
     assert HtmlValidator.validate_table_accessibility(two_tables).__dict__ == table_info.__dict__
 
+def test_validate_headings_accessibility_good_html(good_html):
+    html_info = HeadingAccessibilityInfo(headings="h1, h2", duplicate_h1s=False, bad_ordering=False, wrong_start=False)
+
+    assert HtmlValidator.validate_headings_accessibility(good_html).__dict__ == html_info.__dict__
+
+def test_validate_headings_accessibility_wrong_start(wrong_start):
+    html_info = HeadingAccessibilityInfo(headings="h2", wrong_start=True)
+
+    assert HtmlValidator.validate_headings_accessibility(wrong_start).__dict__ == html_info.__dict__


### PR DESCRIPTION
This PR adds an additional column to the HeadingOrderingReport to better differentiate documents that do not start with an H1. 

Previously this information was provided by marking bad_ordering as `true` and returning just the first header.

It also ensures that in all cases the full list of headings is returned for each case, as this can be useful.