### PR TITLE
Add organisation to reports

### DIFF
--- a/src/helpers/preprocess_text.py
+++ b/src/helpers/preprocess_text.py
@@ -61,6 +61,34 @@ def extract_links_from_content_details(data):
         return extract_links_from_html(data)
     return []
 
+def extract_primary_org_from_organisations(content_item_orgs):
+    """
+    Parses Content Item list of Organisations, extracts the Primary Publishing Organisation
+    and returns its title.
+    Falls back to first Organisation if there is no Primary Publishing Organisation.
+    Structure of `orgs` would look like:
+    {
+        'organisations': [
+            ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
+        ],
+        'primary_publishing_organisation': [
+            ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
+        ]
+    }
+    """
+
+    primary = None
+    orgs = ast.literal_eval(content_item_orgs)
+
+    try:
+        if orgs is not None:
+            primary = (orgs.get('primary_publishing_organisation'))[0][1]
+        if primary is None:
+            primary = (orgs.get('organisations'))[0][1]
+    except TypeError:
+        primary = "NO ORG"
+
+    return primary
 
 def remove_tables_from_html(html):
     soup = BeautifulSoup(html, "lxml")

--- a/src/report_generators/heading_ordering_report_generator.py
+++ b/src/report_generators/heading_ordering_report_generator.py
@@ -1,11 +1,12 @@
 from src.utils.html_validator import HtmlValidator
 from src.report_generators.base_report_generator import BaseReportGenerator
+from src.helpers.preprocess_text import extract_subtext
 
 
 class HeadingOrderingReportGenerator(BaseReportGenerator):
     @property
     def headers(self):
-        return ["base_path", "has_valid_headings", "has_duplicate_h1s", "has_bad_ordering", "has_no_headings",
+        return ["base_path", "primary_publishing_organisation", "has_valid_headings", "has_duplicate_h1s", "has_bad_ordering", "has_no_headings",
                 "heading_order"]
 
     @property
@@ -15,8 +16,40 @@ class HeadingOrderingReportGenerator(BaseReportGenerator):
     def process_page(self, content_item, html):
         heading_accessibility_info = HtmlValidator.validate_headings_accessibility(html)
 
-        row = [content_item['base_path'], heading_accessibility_info.is_valid(),
+        # extract primary publishing organisation
+        primary_publishing_organisation = self.__primary_org(content_item['organisations'])
+
+        row = [content_item['base_path'], primary_publishing_organisation, heading_accessibility_info.is_valid(),
                heading_accessibility_info.has_duplicate_h1s(), heading_accessibility_info.has_bad_ordering(),
                heading_accessibility_info.has_no_headings(), heading_accessibility_info.heading_order()]
 
         return row
+
+    @staticmethod
+    def __primary_org(content_item_orgs) -> str:
+        # Parses Content Item list of Organisations, extracts the Primary Publishing Organisation
+        #  and returns its title.
+        #  Falls back to first Organisation if there is no Primary Publishing Organisation.
+        #
+        # Structure of `orgs` would look like:
+        # {
+        #     'organisations': [
+        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
+        #     ],
+        #     'primary_publishing_organisation': [
+        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
+        #     ]
+        # }
+
+        primary = None
+        orgs = ast.literal_eval(content_item_orgs)
+
+        try:
+            if orgs is not None:
+                primary = (orgs.get('primary_publishing_organisation'))[0][1]
+            if primary is None:
+                primary = (orgs.get('organisations'))[0][1]
+        except TypeError:
+            primary = "NO ORG"
+
+        return primary

--- a/src/report_generators/heading_ordering_report_generator.py
+++ b/src/report_generators/heading_ordering_report_generator.py
@@ -1,6 +1,6 @@
 from src.utils.html_validator import HtmlValidator
 from src.report_generators.base_report_generator import BaseReportGenerator
-from src.helpers.preprocess_text import extract_subtext
+from src.helpers.preprocess_text import extract_primary_org_from_organisations
 
 
 class HeadingOrderingReportGenerator(BaseReportGenerator):
@@ -17,7 +17,7 @@ class HeadingOrderingReportGenerator(BaseReportGenerator):
         heading_accessibility_info = HtmlValidator.validate_headings_accessibility(html)
 
         # extract primary publishing organisation
-        primary_publishing_organisation = self.__primary_org(content_item['organisations'])
+        primary_publishing_organisation = extract_primary_org_from_organisations(content_item['organisations'])
 
         row = [content_item['base_path'], primary_publishing_organisation, heading_accessibility_info.is_valid(),
                heading_accessibility_info.has_duplicate_h1s(), heading_accessibility_info.has_bad_ordering(),
@@ -25,31 +25,3 @@ class HeadingOrderingReportGenerator(BaseReportGenerator):
 
         return row
 
-    @staticmethod
-    def __primary_org(content_item_orgs) -> str:
-        # Parses Content Item list of Organisations, extracts the Primary Publishing Organisation
-        #  and returns its title.
-        #  Falls back to first Organisation if there is no Primary Publishing Organisation.
-        #
-        # Structure of `orgs` would look like:
-        # {
-        #     'organisations': [
-        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
-        #     ],
-        #     'primary_publishing_organisation': [
-        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
-        #     ]
-        # }
-
-        primary = None
-        orgs = ast.literal_eval(content_item_orgs)
-
-        try:
-            if orgs is not None:
-                primary = (orgs.get('primary_publishing_organisation'))[0][1]
-            if primary is None:
-                primary = (orgs.get('organisations'))[0][1]
-        except TypeError:
-            primary = "NO ORG"
-
-        return primary

--- a/src/report_generators/non_english_docs_report_generator.py
+++ b/src/report_generators/non_english_docs_report_generator.py
@@ -8,7 +8,7 @@ import pandas as pd
 class NonEnglishDocsReportGenerator(BaseReportGenerator):
     @property
     def headers(self):
-        return ["base_path", "text", "text_languages", "detected_as_english"]
+        return ["base_path", "primary_publishing_organisation", "text", "text_languages", "detected_as_english"]
 
     @property
     def filename(self):
@@ -18,6 +18,8 @@ class NonEnglishDocsReportGenerator(BaseReportGenerator):
         if pd.isna(content_item['text']):
             return [content_item['base_path'], content_item['text'], [], content_item.get('detected_as_english',
                                                                                           default=False)]
+        # extract primary publishing organisation
+        primary_publishing_organisation = self.__primary_org(content_item['organisations'])
 
         content_item['text'] = str(content_item['text'])
 
@@ -27,7 +29,10 @@ class NonEnglishDocsReportGenerator(BaseReportGenerator):
         if 'en' in languages_dict and languages_dict['en'] > 0.5:
             content_item['detected_as_english'] = True
 
-        return [content_item['base_path'], content_item['text'], content_item['text_lang'],
+        return [content_item['base_path'],
+                primary_publishing_organisation,
+                content_item['text'],
+                content_item['text_lang'],
                 content_item.get('detected_as_english', default=False)]
 
     def detect_languages(self, text):
@@ -41,3 +46,32 @@ class NonEnglishDocsReportGenerator(BaseReportGenerator):
             return detect_langs(text)
         except LangDetectException:
             return []
+
+    @staticmethod
+    def __primary_org(content_item_orgs) -> str:
+        # Parses Content Item list of Organisations, extracts the Primary Publishing Organisation
+        #  and returns its title.
+        #  Falls back to first Organisation if there is no Primary Publishing Organisation.
+        #
+        # Structure of `orgs` would look like:
+        # {
+        #     'organisations': [
+        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
+        #     ],
+        #     'primary_publishing_organisation': [
+        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
+        #     ]
+        # }
+
+        primary = None
+        orgs = ast.literal_eval(content_item_orgs)
+
+        try:
+            if orgs is not None:
+                primary = (orgs.get('primary_publishing_organisation'))[0][1]
+            if primary is None:
+                primary = (orgs.get('organisations'))[0][1]
+        except TypeError:
+            primary = "NO ORG"
+
+        return primary

--- a/src/report_generators/non_english_docs_report_generator.py
+++ b/src/report_generators/non_english_docs_report_generator.py
@@ -1,6 +1,7 @@
 from langdetect import detect_langs
 from langdetect.lang_detect_exception import LangDetectException
 from src.report_generators.base_report_generator import BaseReportGenerator
+from src.helpers.preprocess_text import extract_primary_org_from_organisations
 
 import pandas as pd
 
@@ -18,8 +19,7 @@ class NonEnglishDocsReportGenerator(BaseReportGenerator):
         if pd.isna(content_item['text']):
             return [content_item['base_path'], content_item['text'], [], content_item.get('detected_as_english',
                                                                                           default=False)]
-        # extract primary publishing organisation
-        primary_publishing_organisation = self.__primary_org(content_item['organisations'])
+        primary_publishing_organisation = extract_primary_org_from_organisations(content_item['organisations'])
 
         content_item['text'] = str(content_item['text'])
 
@@ -46,32 +46,3 @@ class NonEnglishDocsReportGenerator(BaseReportGenerator):
             return detect_langs(text)
         except LangDetectException:
             return []
-
-    @staticmethod
-    def __primary_org(content_item_orgs) -> str:
-        # Parses Content Item list of Organisations, extracts the Primary Publishing Organisation
-        #  and returns its title.
-        #  Falls back to first Organisation if there is no Primary Publishing Organisation.
-        #
-        # Structure of `orgs` would look like:
-        # {
-        #     'organisations': [
-        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
-        #     ],
-        #     'primary_publishing_organisation': [
-        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
-        #     ]
-        # }
-
-        primary = None
-        orgs = ast.literal_eval(content_item_orgs)
-
-        try:
-            if orgs is not None:
-                primary = (orgs.get('primary_publishing_organisation'))[0][1]
-            if primary is None:
-                primary = (orgs.get('organisations'))[0][1]
-        except TypeError:
-            primary = "NO ORG"
-
-        return primary

--- a/src/report_generators/tables_report_generator.py
+++ b/src/report_generators/tables_report_generator.py
@@ -2,6 +2,7 @@ import ast
 
 from src.utils.html_validator import HtmlValidator
 from src.report_generators.base_report_generator import BaseReportGenerator
+from src.helpers.preprocess_text import extract_primary_org_from_organisations
 
 
 class TablesReportGenerator(BaseReportGenerator):
@@ -21,7 +22,7 @@ class TablesReportGenerator(BaseReportGenerator):
         if accessibility.has_tables is not True or (accessibility.num_of_tables == 1 and accessibility.two_columns is True):
             return []
 
-        primary = self.__primary_org(content_item['organisations'])
+        primary = extract_primary_org_from_organisations(content_item['organisations'])
 
         row = ["https://gov.uk" + content_item['base_path'],
                primary,
@@ -31,32 +32,3 @@ class TablesReportGenerator(BaseReportGenerator):
                accessibility.two_columns]
 
         return row
-
-    @staticmethod
-    def __primary_org(content_item_orgs) -> str:
-        # Parses Content Item list of Organisations, extracts the Primary Publishing Organisation
-        #  and returns its title.
-        #  Falls back to first Organisation if there is no Primary Publishing Organisation.
-        #
-        # Structure of `orgs` would look like:
-        # {
-        #     'organisations': [
-        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
-        #     ],
-        #     'primary_publishing_organisation': [
-        #         ('b548a09f-8b35-4104-89f4-f1a40bf3136d', 'Department for Work and Pensions', 'D10')
-        #     ]
-        # }
-
-        primary = None
-        orgs = ast.literal_eval(content_item_orgs)
-
-        try:
-            if orgs is not None:
-                primary = (orgs.get('primary_publishing_organisation'))[0][1]
-            if primary is None:
-                primary = (orgs.get('organisations'))[0][1]
-        except TypeError:
-            primary = "NO ORG"
-
-        return primary


### PR DESCRIPTION
This PR adds an additional column to show the primary publishing organisation to the CSV output for 
HeadingOrderingReport
NonEnglishDocsReport

There are various ways of obtaining the primary publishing organisation used in the other reports. This one is based on that found in the TableReport, as it appears the most robust and can handle scenarios such as a primary publishing organisation not being present in the content item.

[trello](https://trello.com/c/SEYsc4f7/1422-ensure-all-govuk-accessibility-reports-include-the-publishing-organisation)