### PR TITLE
Link accessibility report

### DIFF
--- a/config/report-config.yaml
+++ b/config/report-config.yaml
@@ -31,6 +31,10 @@ reports:
     filename: table_relationship_report_generator.py
     class: TableRelationshipReportGenerator
     skip: true
+  - name: Check descriptions around attachments are accurate
+    filename: attachment_description_report_generator.py
+    class: AttachmentDescriptionReportGenerator
+    skip: true
   - name: Find images with missing or broken alt tags
     filename: alt_tag_report_generator.py
     class: AltTagReportGenerator

--- a/src/report_generators/attachment_description_report_generator.py
+++ b/src/report_generators/attachment_description_report_generator.py
@@ -1,0 +1,47 @@
+from src.report_generators.base_report_generator import BaseReportGenerator
+from src.helpers.preprocess_text import extract_subtext
+from src.utils.constants import ATTACHMENTS
+from src.utils.html_validator import HtmlValidator
+
+from src.utils.content_item_details import content_item_details, html_from_content_details
+
+class AttachmentDescriptionReportGenerator(BaseReportGenerator):
+    @property
+    def headers(self):
+        return ["base_path",
+                "primary_publishing_organisation",
+                "is_valid",
+                "inaccurately_describes_pdf_as_download",
+                "no_mention_of_format",
+                "no_mention_of_size"]
+
+    @property
+    def filename(self):
+        return "attachment_description_report.csv"
+
+    def process_page(self, content_item, html):
+        # ignore empty details
+        if not content_item['details']:
+            return []
+
+        # extract primary publishing organisations
+        content_item['primary_publishing_organisation'] = extract_subtext(text=content_item['organisations'],
+                                                                          key='primary_publishing_organisation',
+                                                                          index=1)
+        details_dict = content_item_details(content_item)
+
+        # extract attachment url
+        attachment_link_accessibility_info = HtmlValidator.validate_attachment_link_accessibility(html_from_content_details(details_dict))
+
+        # return only pages with relevant attachment links and problems
+        if not attachment_link_accessibility_info.has_attachment_links():
+            return []
+        elif attachment_link_accessibility_info.is_valid():
+            return []
+        else:
+            return [content_item['base_path'],
+                    content_item['primary_publishing_organisation'][0],
+                    str(attachment_link_accessibility_info.is_valid()),
+                    str(attachment_link_accessibility_info.has_inaccurate_pdf_download_text()),
+                    str(attachment_link_accessibility_info.has_no_format_description()),
+                    str(attachment_link_accessibility_info.has_no_size_description())]

--- a/src/utils/attachment_link_accessibility_info.py
+++ b/src/utils/attachment_link_accessibility_info.py
@@ -1,0 +1,26 @@
+class AttachmentLinkAccessibilityInfo:
+    def __init__(self, attachment_links, inaccurate_pdf_download_text=False, no_format_description=False, no_size_description=False):
+        self.attachment_links = attachment_links
+        self.inaccurate_pdf_download_text = inaccurate_pdf_download_text
+        self.no_format_description = no_format_description
+        self.no_size_description = no_size_description
+
+    def attachment_links(self):
+        return self.attachment_links
+
+    def has_attachment_links(self):
+        return len(self.attachment_links) > 0
+
+    def has_inaccurate_pdf_download_text(self):
+        return self.inaccurate_pdf_download_text
+
+    def has_no_format_description(self):
+        return self.no_format_description
+
+    def has_no_size_description(self):
+        return self.no_size_description
+
+    def is_valid(self):
+        if self.has_attachment_links() == False:
+            return True
+        return not self.has_inaccurate_pdf_download_text() and not self.has_no_format_description() and not self.has_no_size_description()


### PR DESCRIPTION
First shot at creating a test for attachment link accessibility. Has been tested on first 1000 records (but they're quite homogenous).

This report:
- only reports on pages with links to non-html attachments (which just happens to be all of them in the first 1000 records)
- Has an “is_valid?” column which is TRUE if all conditions are correct, FALSE otherwise
- Has an “inaccurately_describes_pdf_as_download” column which is TRUE if the attachment is a PDF and the relevant link text (see below) contains the word Download, FALSE if the link isn’t a PDF or isn’t described as a download.
- Has a “no_mention_of_format” column which is TRUE if the relevant text doesn’t contain the file extension, FALSE if it does.
- Has a “no_mention_of_size” column which is TRUE if the relevant text doesn’t contain “kb”, “mb” or “gb”, FALSE if it does.

(Relevant text is defined as: The link text, any text in the P tag which surrounds the link, and any text in the P tag’s previous sibling - in these examples usually an h3 immediately above it).

https://trello.com/c/mpZzOPr2/1358-find-further-instances-of-problem-instances-across-govuk