### PR TITLE
Table relationships

### DIFF
--- a/config/report-config.yaml
+++ b/config/report-config.yaml
@@ -27,6 +27,10 @@ reports:
     filename: attachment_type_report_generator.py
     class: AttachmentTypeReportGenerator
     skip: true
+  - name: Find text which refers to table that isn't in the text
+    filename: table_relationship_report_generator.py
+    class: TableRelationshipReportGenerator
+    skip: true
 
 settings:
   turbo_mode: false

--- a/src/report_generators/table_relationship_report_generator.py
+++ b/src/report_generators/table_relationship_report_generator.py
@@ -1,0 +1,53 @@
+from src.report_generators.base_report_generator import BaseReportGenerator
+from src.helpers.preprocess_text import extract_subtext
+from src.utils.constants import ATTACHMENTS
+from src.utils.html_validator import HtmlValidator
+
+from src.utils.content_item_details import content_item_details, html_from_content_details
+
+class TableRelationshipReportGenerator(BaseReportGenerator):
+    @property
+    def headers(self):
+        return ["base_path",
+                "primary_publishing_organisation",
+                "is_valid",
+                "mentions_table",
+                "table_in_document",
+                "possible_table_attachment"]
+
+    @property
+    def filename(self):
+        return "table_relationship_report.csv"
+
+    def process_page(self, content_item, html):
+        # ignore empty details
+        if not content_item['details']:
+            return []
+
+        # extract primary publishing organisations
+        content_item['primary_publishing_organisation'] = extract_subtext(text=content_item['organisations'],
+                                                                          key='primary_publishing_organisation',
+                                                                          index=1)
+        details_dict = content_item_details(content_item)
+
+        # extract attachment url
+        if "body" not in details_dict:
+            return []
+
+        html_parts = html_from_content_details(details_dict)
+        if html_parts == None:
+            return []
+        table_relationship_info = HtmlValidator.validate_table_relationships(html_parts)
+
+        # return only pages with relevant attachment links and problems
+        if not table_relationship_info.has_mention_of_table():
+            return []
+        elif table_relationship_info.is_valid():
+            return []
+        else:
+            return [content_item['base_path'],
+                    content_item['primary_publishing_organisation'][0],
+                    str(table_relationship_info.is_valid()),
+                    str(table_relationship_info.has_mention_of_table()),
+                    str(table_relationship_info.has_table_in_document()),
+                    str(table_relationship_info.has_possible_table_attachment())]

--- a/src/utils/content_item_details.py
+++ b/src/utils/content_item_details.py
@@ -1,0 +1,28 @@
+# Helps extract HTML/Govspeak from the mismash string content item details
+# that is being passed to the report generators
+#
+# To use, first get the content details, then you can pass that to one
+# of the xxx_from_content_details methods:
+#
+# from src.utils.content_item_details import content_details, html_from_content_details
+# cd = content_item_details(content_item)
+# html = html_from_content_details(cd)
+#
+# (html is just the html of the content item, can be parsed with BeautifulSoup)
+#
+
+def content_item_details(content_item):
+    return eval(content_item['details'])
+
+def format_from_content_details_body(body, content_type) -> str:
+    content = [f['content'] for f in body if f['content_type'] == content_type]
+    if len(content) == 0:
+        return None
+    else:
+        return content[0]
+
+def html_from_content_details(details) -> str:
+    return format_from_content_details_body(details['body'], 'text/html')
+
+def govspeak_from_content_details(details) -> str:
+    return format_from_content_details_body(details['body'], 'text/govspeak')

--- a/src/utils/content_item_details.py
+++ b/src/utils/content_item_details.py
@@ -15,6 +15,8 @@ def content_item_details(content_item):
     return eval(content_item['details'])
 
 def format_from_content_details_body(body, content_type) -> str:
+    if type(body) == str:
+        return body
     content = [f['content'] for f in body if f['content_type'] == content_type]
     if len(content) == 0:
         return None

--- a/src/utils/html_extractor.py
+++ b/src/utils/html_extractor.py
@@ -1,6 +1,6 @@
+from src.utils.constants import ATTACHMENTS
 import re
 from bs4 import BeautifulSoup
-
 
 class HtmlExtractor:
     header_regex = re.compile("^h[1-6]{1}$")
@@ -18,3 +18,25 @@ class HtmlExtractor:
         soup = BeautifulSoup(html, 'html5lib')
         matches = soup.find_all(cls.header_regex)
         return [m.name for m in matches if m.text.strip() not in cls.excluded_headings]
+
+    @classmethod
+    def extract_links(cls, html):
+        soup = BeautifulSoup(html, 'html5lib')
+        links = soup.find_all(name="a", href=True)
+        return links
+
+    @classmethod
+    def extract_attachment_links(cls, html):
+        soup = BeautifulSoup(html, 'html5lib')
+        links = soup.find_all(name="a", href=True)
+        attachment_links = [l for l in links if HtmlExtractor.is_attachment_link(l)]
+        return links
+
+    @staticmethod
+    def link_extension(link):
+        parts = link.attrs['href'].split('.')
+        return parts[-1].lower()
+
+    @staticmethod
+    def is_attachment_link(link):
+        return ("." + HtmlExtractor.link_extension(link)) in ATTACHMENTS

--- a/src/utils/html_table_extractor.py
+++ b/src/utils/html_table_extractor.py
@@ -1,12 +1,12 @@
 import re
 from bs4 import BeautifulSoup
 
-
 class HtmlTableExtractor:
 
     no_th_css = "table > :not(thead):first-child > tr:first-child > :not(th)"
     no_row_header_css = "table tbody tr:nth-child(2) th:not([scope=row]), table tbody tr:first-child *:not(th):first-child"
     two_column_table_css = "td:first-child:nth-last-child(2), td:first-child:nth-last-child(2) ~ td"
+    table_mentions = "(the|see|in) table"
 
     @classmethod
     def extract_tables(cls, html):
@@ -36,5 +36,12 @@ class HtmlTableExtractor:
     def extract_two_column_tables(cls, tables):
         soup = BeautifulSoup(str(tables), "html5lib")
         matches = soup.select(cls.two_column_table_css)
+
+        return list(matches)
+
+    @classmethod
+    def extract_table_mentions(cls, html):
+        soup = BeautifulSoup(str(html), "html5lib")
+        matches = soup.body.findAll(text=re.compile(cls.table_mentions, re.IGNORECASE))
 
         return list(matches)

--- a/src/utils/html_validator.py
+++ b/src/utils/html_validator.py
@@ -2,7 +2,7 @@ from src.utils.html_extractor import HtmlExtractor
 from src.utils.html_table_extractor import HtmlTableExtractor
 from src.utils.heading_accessibility_info import HeadingAccessibilityInfo
 from src.utils.table_accessibility_info import TableAccessibilityInfo
-
+from src.utils.table_relationship_info import TableRelationshipInfo
 
 class HtmlValidator:
 
@@ -65,3 +65,18 @@ class HtmlValidator:
             two_columns = True
 
         return TableAccessibilityInfo(has_tables=has_tables, num_of_tables=num_of_tables, no_headers=no_headers, no_row_headers=no_row_headers, two_columns=two_columns)
+
+    def validate_table_relationships(html):
+        table_mentions = HtmlTableExtractor.extract_table_mentions(html)
+
+        if len(table_mentions) == 0:
+            return TableRelationshipInfo([], [])
+
+        tables = HtmlTableExtractor.extract_tables(html)
+
+        if tables is not None :
+            return TableRelationshipInfo(table_mentions, [], table_in_document=True)
+
+        attachment_links = HtmlExtractor.extract_attachment_links(html)
+
+        return TableRelationshipInfo(table_mentions, attachment_links, table_in_document=False)

--- a/src/utils/table_relationship_info.py
+++ b/src/utils/table_relationship_info.py
@@ -1,0 +1,22 @@
+class TableRelationshipInfo:
+    def __init__(self, table_mentions, attachments, table_in_document=False):
+        self.table_mentions = table_mentions
+        self.attachments = attachments
+        self.table_in_document = table_in_document
+
+    def table_mentions(self):
+        return self.table_mentions
+
+    def has_mention_of_table(self):
+        return len(self.table_mentions) > 0
+
+    def has_table_in_document(self):
+        return self.table_in_document
+
+    def has_possible_table_attachment(self):
+        return len(self.attachments) > 0
+
+    def is_valid(self):
+        if self.has_table_in_document() == True:
+            return True
+        return not self.has_mention_of_table()

--- a/tests/fixtures/tables.py
+++ b/tests/fixtures/tables.py
@@ -75,6 +75,21 @@ two_tables_string ="""
     <table><tr><td>2</td></tr></table>
 """
 
+good_table_mention_string="""
+    <table><thead><tr><th>Expected</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>
+    <p>The table shows the data expected</p>
+"""
+
+bad_table_mention_string="""
+    <p>The table shows the data expected</p>
+    <a href="whatever">Hello</a>
+"""
+
+missing_table_mention_string="""
+    <p>by putting food on your table!</p>
+"""
+
+
 @pytest.fixture
 def good_table():
     return good_table_string
@@ -91,6 +106,18 @@ def bad_table_missing_row_scope():
 @pytest.fixture
 def two_tables():
     return two_tables_string
+
+@pytest.fixture
+def good_table_mention():
+    return good_table_mention_string
+
+@pytest.fixture
+def bad_table_mention():
+    return bad_table_mention_string
+
+@pytest.fixture
+def missing_table_mention():
+    return missing_table_mention_string
 
 @pytest.fixture
 def html():

--- a/tests/utils/test_html_table_extractor.py
+++ b/tests/utils/test_html_table_extractor.py
@@ -1,7 +1,7 @@
 import pytest
 
 from src.utils.html_table_extractor import HtmlTableExtractor
-from tests.fixtures.tables import good_table, bad_table, bad_table_missing_row_scope, html
+from tests.fixtures.tables import good_table, bad_table, bad_table_missing_row_scope, html, good_table_mention, bad_table_mention, missing_table_mention
 
 
 def test_extract_tables(html):
@@ -46,3 +46,14 @@ def test_extract_two_column_tables(html, bad_table):
 def test_extract_nothing_two_column_tables(good_table):
     tables = HtmlTableExtractor.extract_two_column_tables(good_table)
     assert len(tables) == 0
+
+def test_extract_no_table_mention(missing_table_mention):
+    table_mentions = HtmlTableExtractor.extract_table_mentions(missing_table_mention)
+    assert len(table_mentions) == 0
+
+def test_extract_a_table_mention(good_table_mention, bad_table_mention):
+    table_mentions = HtmlTableExtractor.extract_table_mentions(good_table_mention)
+    assert len(table_mentions) == 1
+
+    table_mentions = HtmlTableExtractor.extract_table_mentions(bad_table_mention)
+    assert len(table_mentions) == 1


### PR DESCRIPTION
Adds a report in: TableRelationshipReportGenerator

Relatively simple test - looks for "the table" in the text of the content item, and checks if an actual table exists in that content item. Reports only on invalid items.