### PR TITLE
Add report checking for invalid alt tags.

### DIFF
--- a/config/report-config.yaml
+++ b/config/report-config.yaml
@@ -31,6 +31,10 @@ reports:
     filename: table_relationship_report_generator.py
     class: TableRelationshipReportGenerator
     skip: true
+  - name: Find images with missing or broken alt tags
+    filename: alt_tag_report_generator.py
+    class: AltTagReportGenerator
+    skip: true
 
 settings:
   turbo_mode: true

--- a/src/report_generators/alt_tag_report_generator.py
+++ b/src/report_generators/alt_tag_report_generator.py
@@ -1,0 +1,51 @@
+from src.report_generators.base_report_generator import BaseReportGenerator
+from src.utils.html_validator import HtmlValidator
+
+from src.utils.content_item_details import content_item_details, html_from_content_details
+
+class AltTagReportGenerator(BaseReportGenerator):
+    @property
+    def headers(self):
+        return self.base_headers() + [
+                    "is_valid",
+                    "has_images",
+                    "missing_alt_tags",
+                    "alt_tags_empty",
+                    "alt_tags_double_quotes",
+                    "alt_tags_filename"
+                ]
+
+    @property
+    def filename(self):
+        return "alt_tags_report.csv"
+
+    def process_page(self, content_item, html):
+        # ignore empty details
+        if not content_item['details']:
+            return []
+
+        details_dict = content_item_details(content_item)
+
+        # extract attachment url
+        if "body" not in details_dict:
+            return []
+
+        html_parts = html_from_content_details(details_dict)
+        if html_parts == None:
+            return []
+        alt_tags_info = HtmlValidator.validate_alt_tags(html_parts)
+
+        # return only pages with relevant attachment links and problems
+        if alt_tags_info.has_images == False:
+            return []
+        elif alt_tags_info.is_valid():
+            return []
+        else:
+            return  self.base_columns(content_item, html) + [
+                        str(alt_tags_info.is_valid()),
+                        str(alt_tags_info.has_images()),
+                        str(alt_tags_info.missing_alt_tags()),
+                        str(alt_tags_info.alt_tags_empty()),
+                        str(alt_tags_info.alt_tags_double_quotes()),
+                        str(alt_tags_info.alt_tags_filename())
+                    ]

--- a/src/utils/alt_tag_info.py
+++ b/src/utils/alt_tag_info.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+@dataclass
+class AltTagInfo:
+    def __init__(self, has_images=False, missing_alt_tags=False, alt_tags_empty=False, alt_tags_double_quotes=False, alt_tags_filename=False):
+        self.has_images = has_images
+        self.missing_alt_tags = missing_alt_tags
+        self.alt_tags_empty = alt_tags_empty
+        self.alt_tags_double_quotes = alt_tags_double_quotes
+        self.alt_tags_filename = alt_tags_filename
+
+    def has_images(self):
+        return self.has_images
+
+    def missing_alt_tags(self):
+        return self.missing_alt_tags
+
+    def alt_tags_empty(self):
+        return self.alt_tags_empty
+
+    def alt_tags_double_quotes(self):
+        return self.alt_tags_double_quotes
+
+    def alt_tags_filename(self):
+        return self.alt_tags_filename
+
+    def is_valid(self):
+        if self.has_images() and (self.missing_alt_tags() or self.alt_tags_empty() or self.alt_tags_double_quotes() or self.alt_tags_filename()):
+            return False
+        return True

--- a/src/utils/html_extractor.py
+++ b/src/utils/html_extractor.py
@@ -40,3 +40,9 @@ class HtmlExtractor:
     @staticmethod
     def is_attachment_link(link):
         return ("." + HtmlExtractor.link_extension(link)) in ATTACHMENTS
+
+    @classmethod
+    def extract_images(cls, html):
+        soup = BeautifulSoup(html, 'html5lib')
+        links = soup.find_all(name="img")
+        return links

--- a/src/utils/html_validator.py
+++ b/src/utils/html_validator.py
@@ -1,5 +1,8 @@
+import re
+
 from src.utils.html_extractor import HtmlExtractor
 from src.utils.html_table_extractor import HtmlTableExtractor
+from src.utils.alt_tag_info import AltTagInfo
 from src.utils.heading_accessibility_info import HeadingAccessibilityInfo
 from src.utils.table_accessibility_info import TableAccessibilityInfo
 from src.utils.table_relationship_info import TableRelationshipInfo
@@ -80,3 +83,30 @@ class HtmlValidator:
         attachment_links = HtmlExtractor.extract_attachment_links(html)
 
         return TableRelationshipInfo(table_mentions, attachment_links, table_in_document=False)
+
+    def validate_alt_tags(html):
+        images = HtmlExtractor.extract_images(html)
+
+        if images == None or len(images) == 0:
+            return AltTagInfo()
+
+        missing_alt_tags = False
+        alt_tags_empty = False
+        alt_tags_double_quotes = False
+        alt_tags_filename = False
+        image_regex = re.compile("png|jpg|webp|_", re.IGNORECASE)
+
+        for image in images:
+            if not 'alt' in image.attrs.keys():
+                missing_alt_tags = True
+            else:
+                if image['alt'] == "":
+                    alt_tags_empty = True
+                if image['alt'] == '""':
+                    alt_tags_double_quotes = True
+                if image_regex.search(image['alt']) != None:
+                    alt_tags_filename = True
+
+
+
+        return AltTagInfo(True, missing_alt_tags, alt_tags_empty, alt_tags_double_quotes, alt_tags_filename)

--- a/tests/fixtures/html.py
+++ b/tests/fixtures/html.py
@@ -31,3 +31,78 @@ def wrong_start():
 """
 
     return html
+
+@pytest.fixture
+def good_alt_tags():
+    html = f"""
+<html>
+<head>
+    <title>Good Alt Tags</title>
+</head>
+<body>
+<img src="myimage.png" alt="Exterior view of Ministry of Silly Walks" />
+</body>
+</html>
+"""
+
+    return html
+
+@pytest.fixture
+def missing_alt_tags():
+    html = f"""
+<html>
+<head>
+    <title>Missing Alt Tags</title>
+</head>
+<body>
+<img src="myimage.png" />
+</body>
+</html>
+"""
+
+    return html
+
+@pytest.fixture
+def empty_alt_tags():
+    html = f"""
+<html>
+<head>
+    <title>Empty Alt Tags</title>
+</head>
+<body>
+<img src="myimage.png" alt=""/>
+</body>
+</html>
+"""
+
+    return html
+
+@pytest.fixture
+def double_quote_alt_tags():
+    html = f"""
+<html>
+<head>
+    <title>Double Quote Alt Tags</title>
+</head>
+<body>
+<img src="myimage.png" alt="&quot;&quot;"/>
+</body>
+</html>
+"""
+
+    return html
+
+@pytest.fixture
+def filename_alt_tags():
+    html = f"""
+<html>
+<head>
+    <title>Filename Alt Tags</title>
+</head>
+<body>
+<img src="myimage.png" alt="myimage.png"/>
+</body>
+</html>
+"""
+
+    return html

--- a/tests/utils/test_html_validator.py
+++ b/tests/utils/test_html_validator.py
@@ -1,11 +1,12 @@
 import pytest
 
 from src.utils.html_validator import HtmlValidator
+from src.utils.alt_tag_info import AltTagInfo
 from src.utils.table_accessibility_info import TableAccessibilityInfo
 from src.utils.heading_accessibility_info import HeadingAccessibilityInfo
 
 from tests.fixtures.tables import two_tables
-from tests.fixtures.html import good_html, wrong_start
+from tests.fixtures.html import good_html, wrong_start, good_alt_tags, missing_alt_tags, empty_alt_tags, double_quote_alt_tags, filename_alt_tags
 
 
 def test_validate_table_accessibility(two_tables):
@@ -22,3 +23,28 @@ def test_validate_headings_accessibility_wrong_start(wrong_start):
     html_info = HeadingAccessibilityInfo(headings="h2", wrong_start=True)
 
     assert HtmlValidator.validate_headings_accessibility(wrong_start).__dict__ == html_info.__dict__
+
+def test_validate_alt_tags_good_tags(good_alt_tags):
+    alt_tag_info = AltTagInfo(True, False, False, False, False)
+
+    assert HtmlValidator.validate_alt_tags(good_alt_tags).__dict__ == alt_tag_info.__dict__
+
+def test_validate_alt_tags_missing_tags(missing_alt_tags):
+    alt_tag_info = AltTagInfo(True, True, False, False, False)
+
+    assert HtmlValidator.validate_alt_tags(missing_alt_tags).__dict__ == alt_tag_info.__dict__
+
+def test_validate_alt_tags_empty_tags(empty_alt_tags):
+    alt_tag_info = AltTagInfo(True, False, True, False, False)
+
+    assert HtmlValidator.validate_alt_tags(empty_alt_tags).__dict__ == alt_tag_info.__dict__
+
+def test_validate_alt_tags_double_quote_tags(double_quote_alt_tags):
+    alt_tag_info = AltTagInfo(True, False, False, True, False)
+
+    assert HtmlValidator.validate_alt_tags(double_quote_alt_tags).__dict__ == alt_tag_info.__dict__
+
+def test_validate_alt_tags_filename_tags(filename_alt_tags):
+    alt_tag_info = AltTagInfo(True, False, False, False, True)
+
+    assert HtmlValidator.validate_alt_tags(filename_alt_tags).__dict__ == alt_tag_info.__dict__


### PR DESCRIPTION
https://trello.com/c/miFt9Z5h/6-check-for-invalid-alt-tags-dacnon-textcontent02

Added report generator: AltTagReportGenerator

Scans pages for image tags and reports any page where is_valid = false, with reasons from:
- one or more images has alt attribute missing
- one or more images has alt attribute empty
- one or more images has an alt attribute which contains double quotes (ie alt="""")
- one or more images has an alt attribute which is probably a filename (contains png, jpg, webp or underscores)