### PR TITLE
Rename methods for AltTagInfo

### DIFF
--- a/src/report_generators/alt_tag_report_generator.py
+++ b/src/report_generators/alt_tag_report_generator.py
@@ -36,16 +36,16 @@ class AltTagReportGenerator(BaseReportGenerator):
         alt_tags_info = HtmlValidator.validate_alt_tags(html_parts)
 
         # return only pages with relevant attachment links and problems
-        if alt_tags_info.has_images == False:
+        if alt_tags_info.includes_images == False:
             return []
         elif alt_tags_info.is_valid():
             return []
         else:
             return  self.base_columns(content_item, html) + [
                         str(alt_tags_info.is_valid()),
-                        str(alt_tags_info.has_images()),
-                        str(alt_tags_info.missing_alt_tags()),
-                        str(alt_tags_info.alt_tags_empty()),
-                        str(alt_tags_info.alt_tags_double_quotes()),
-                        str(alt_tags_info.alt_tags_filename())
+                        str(alt_tags_info.includes_images()),
+                        str(alt_tags_info.missing_tags()),
+                        str(alt_tags_info.tags_empty()),
+                        str(alt_tags_info.tags_double_quotes()),
+                        str(alt_tags_info.tags_filename())
                     ]

--- a/src/utils/alt_tag_info.py
+++ b/src/utils/alt_tag_info.py
@@ -9,22 +9,22 @@ class AltTagInfo:
         self.alt_tags_double_quotes = alt_tags_double_quotes
         self.alt_tags_filename = alt_tags_filename
 
-    def has_images(self):
+    def includes_images(self):
         return self.has_images
 
-    def missing_alt_tags(self):
+    def missing_tags(self):
         return self.missing_alt_tags
 
-    def alt_tags_empty(self):
+    def tags_empty(self):
         return self.alt_tags_empty
 
-    def alt_tags_double_quotes(self):
+    def tags_double_quotes(self):
         return self.alt_tags_double_quotes
 
-    def alt_tags_filename(self):
+    def tags_filename(self):
         return self.alt_tags_filename
 
     def is_valid(self):
-        if self.has_images() and (self.missing_alt_tags() or self.alt_tags_empty() or self.alt_tags_double_quotes() or self.alt_tags_filename()):
+        if self.includes_images() and (self.missing_tags() or self.tags_empty() or self.tags_double_quotes() or self.tags_filename()):
             return False
         return True


### PR DESCRIPTION
Methods with the same name as their class instance causes `TypeError: 'bool' object is not callable`.