### PR TITLE
Prevent HeadingOrderingReport from returning valid results

### DIFF
--- a/src/report_generators/heading_ordering_report_generator.py
+++ b/src/report_generators/heading_ordering_report_generator.py
@@ -20,8 +20,14 @@ class HeadingOrderingReportGenerator(BaseReportGenerator):
     def process_page(self, content_item, html):
         heading_accessibility_info = HtmlValidator.validate_headings_accessibility(html)
 
-        row = self.base_columns(content_item, html) + [heading_accessibility_info.is_valid(),
-               heading_accessibility_info.has_duplicate_h1s(), heading_accessibility_info.has_wrong_start(), heading_accessibility_info.has_bad_ordering(),
-               heading_accessibility_info.has_no_headings(), heading_accessibility_info.heading_order()]
-
-        return row
+        if heading_accessibility_info.is_valid() == True:
+            return []
+        else:
+            return  self.base_columns(content_item, html) + [
+                        str(heading_accessibility_info.is_valid()),
+                        str(heading_accessibility_info.has_duplicate_h1s()),
+                        str(heading_accessibility_info.has_wrong_start()),
+                        str(heading_accessibility_info.has_bad_ordering()),
+                        str(heading_accessibility_info.has_no_headings()),
+                        str(heading_accessibility_info.heading_order())
+                    ]


### PR DESCRIPTION
This PR should prevent documents with valid headings from appearing in the output.