### PR TITLE
Add filters attachment links report

### DIFF
--- a/src/utils/content_item_details.py
+++ b/src/utils/content_item_details.py
@@ -24,7 +24,10 @@ def format_from_content_details_body(body, content_type) -> str:
         return content[0]
 
 def html_from_content_details(details) -> str:
-    return format_from_content_details_body(details['body'], 'text/html')
+    body = format_from_content_details_body(details['body'], 'text/html')
+    if 'documents' in details and len(details['documents']) > 0:
+        body += details['documents'][0]
+    return body
 
 def govspeak_from_content_details(details) -> str:
     return format_from_content_details_body(details['body'], 'text/govspeak')

--- a/src/utils/html_validator.py
+++ b/src/utils/html_validator.py
@@ -90,6 +90,7 @@ class HtmlValidator:
     @staticmethod
     def validate_attachment_link_accessibility(html):
         attachment_links = HtmlExtractor.extract_attachment_links(html)
+        attachment_links = [l for l in attachment_links if HtmlValidator.is_type_1_attachment_link(l)]
 
         if len(attachment_links) == 0:
             return AttachmentLinkAccessibilityInfo([])
@@ -132,6 +133,29 @@ class HtmlValidator:
             if parent_sib is not None:
                 texts.append(parent_sib.text)
         return " ".join(texts)
+
+    @staticmethod
+    def is_type_1_attachment_link(link):
+        # Type 2 has a parent span with 'attachment-inline' class
+        span_parent = link.find_parent('span')
+        if span_parent != None and 'class' in span_parent.attrs and 'attachment-inline' in span_parent.attrs['class']:
+            return False
+
+        # Type 3 has 'gem-c-attachment__link' class itself
+        if 'gem-c-attachment__link' and 'class' in link.attrs in link.attrs['class']:
+            return False
+
+        # Type 4 has an ancestory section with 'gem-c-attachment' class
+        section_ancestor = link.find_parent('section')
+        if section_ancestor != None and 'class' in section_ancestor.attrs and 'gem-c-attachment' in section_ancestor.attrs['class']:
+            return False
+
+        # Type 5 has an ancestor section with 'attachment embedded' classes
+        if section_ancestor != None and 'class' in section_ancestor.attrs and 'attachment' in section_ancestor.attrs['class']:
+            return False
+
+        return True
+
 
     @staticmethod
     def describes_link_as_download(text):


### PR DESCRIPTION
Filter out attachment links that are component-based (and so will be fixed if/when the components are fixed), so that we can focus on individual raw attachments that have to be fixed by departments.

https://trello.com/c/y7vuLqc8/2-daclinkstonon-htmldocuments02-second-issue